### PR TITLE
line zindex fix

### DIFF
--- a/components/HeroScrollLine.js
+++ b/components/HeroScrollLine.js
@@ -6,9 +6,9 @@ import React from 'react';
 
 export default function HeroScrollLine () {
   return (
-  <div className='absolute z-[1500] italic w-[1px] h-[320px] bottom-0 bg-[#0a1b29] flex-col align-middle'>
+  <div className='absolute z-30 italic w-[1px] h-[320px] bottom-0 bg-[#0a1b29] flex-col align-middle'>
     <span className='absolute top-[-60px] text-white tracking-widest text-[12px] [line-height:0;] origin-bottom-left rotate-90  align-baseline'>SCROLL</span>
-    <div className='absolute z-[1600]  italic  w-[1px] h-[320px] bg-white ease animate-lineFlow'></div>
+    <div className='absolute z-40  italic  w-[1px] h-[320px] bg-white ease animate-lineFlow'></div>
   </div>
   )
 }


### PR DESCRIPTION
z-indexの数値を修正（navpanelを最前面に位置させるための修正）
before：下に位置させたいscroll要素がz-1500で、navpanelがz-50〜500を指定していた。
after：scrollのz-index（グレー線30,白線50）に指定し、navpanelの背面に位置させた。